### PR TITLE
faster entropy-pooling version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,36 +16,36 @@ Depends:
     R (>= 2.10)
 Imports: 
     assertthat (>= 0.2.1),
-    dplyr (>= 1.0.8),
+    dplyr (>= 1.0.9),
     forcats (>= 0.5.1),
     ggdist (>= 3.1.1),
-    ggplot2 (>= 3.3.5),
+    ggplot2 (>= 3.3.6),
     lubridate (>= 1.8.0),
-    magrittr (>= 2.0.2),
+    magrittr (>= 2.0.3),
     methods,
     mvtnorm (>= 1.1-3),
     purrr (>= 0.3.4),
     rlang (>= 1.0.2),
-    scales (>= 1.1.1),
+    scales (>= 1.2.0),
     stringr (>= 1.4.0),
     stats,
-    tibble (>= 3.1.6),
+    tibble (>= 3.1.7),
     tidyr (>= 1.2.0),
-    vctrs (>= 0.3.8),
-    nloptr (>= 2.0.0),
+    vctrs (>= 0.4.1),
+    nloptr (>= 2.0.3),
     crayon,
     NlcOptim (>= 0.6)
 Suggests: 
     covr,
-    knitr (>= 1.37),
+    knitr (>= 1.39),
     markdown,
     roxygen2,
     spelling,
-    testthat (>= 3.1.2), 
+    testthat (>= 3.1.4), 
     xts (>= 0.12.1)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/R/views.R
+++ b/R/views.R
@@ -44,7 +44,7 @@ view_on_mean <- function(x, mean) {
 #' @rdname view_on_mean
 #' @export
 view_on_mean.default <- function(x, mean) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_mean
@@ -132,7 +132,7 @@ view_on_covariance <- function(x, mean, sigma) {
 #' @keywords internal
 #' @rdname view_on_covariance
 view_on_covariance.default <- function(x, mean, sigma) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_covariance
@@ -230,7 +230,7 @@ view_on_correlation <- function(x, cor) {
 #' @rdname view_on_correlation
 #' @export
 view_on_correlation.default <- function(x, cor) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_correlation
@@ -327,7 +327,7 @@ view_on_volatility <- function(x, vol) {
 #' @rdname view_on_volatility
 #' @export
 view_on_volatility.default <- function(x, vol) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_volatility
@@ -353,9 +353,6 @@ construct_view_on_volatility <- function(x, vol) {
 
   assertthat::assert_that(assertthat::are_equal(NCOL(x), vctrs::vec_size(vol)))
   vctrs::vec_assert(vol, double())
-
-  Aeq <- NULL
-  #beq <- NULL
 
   Aeq <- t(x) ^ 2
   beq <- colMeans(x) ^ 2 + vol ^ 2
@@ -413,7 +410,7 @@ view_on_rank <- function(x, rank) {
 #' @rdname view_on_rank
 #' @export
 view_on_rank.default <- function(x, rank) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_rank
@@ -584,7 +581,7 @@ view_on_copula <- function(x, simul, p) {
 #' @rdname view_on_copula
 #' @export
 view_on_copula.default <- function(x, simul, p) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_copula
@@ -615,10 +612,15 @@ construct_view_on_copula <- function(x, simul, p) {
   Aeq <- NULL
   beq <- NULL
 
+  # first moment
   Aeq <- rbind(Aeq, t(x))
   beq <- as.matrix(c(beq, rep(1 / 2, NCOL(x))))
 
-  # order 2
+  # second moment
+  Aeq <- rbind(Aeq, t(x) ^ 2)
+  beq <- as.matrix(c(beq, rep(1 / 3, NCOL(x))))
+
+  # cross moments
   for (k in 1:N) {
     for (l in k:N) {
       Aeq <- rbind(Aeq, t(x[ , k] * x[ , l]))
@@ -627,14 +629,14 @@ construct_view_on_copula <- function(x, simul, p) {
   }
 
   # order 3
-  for (k in 1:N) {
-    for (l in k:N) {
-      for (i in l:k) {
-        Aeq <- rbind(Aeq, t(x[ , k] * x[ , l] * x[ , i]))
-        beq <- rbind(beq, t(simul[ , k] * simul[ , l] * simul[ , i]) %*% p)
-      }
-    }
-  }
+  # for (k in 1:N) {
+  #   for (l in k:N) {
+  #     for (i in l:k) {
+  #       Aeq <- rbind(Aeq, t(x[ , k] * x[ , l] * x[ , i]))
+  #       beq <- rbind(beq, t(simul[ , k] * simul[ , l] * simul[ , i]) %*% p)
+  #     }
+  #   }
+  # }
 
   vctrs::new_list_of(
     x = list(Aeq = Aeq, beq = beq),
@@ -697,7 +699,7 @@ view_on_marginal_distribution <- function(x, simul, p) {
 #' @rdname view_on_marginal_distribution
 #' @export
 view_on_marginal_distribution.default <- function(x, simul, p) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_marginal_distribution
@@ -807,7 +809,7 @@ view_on_joint_distribution <- function(x, simul, p) {
 #' @rdname view_on_joint_distribution
 #' @export
 view_on_joint_distribution.default <- function(x, simul, p) {
-  stop("Method not implemented for class `", class(x), "` yet.", call. = FALSE)
+  rlang::abort("Method not implemented for class `", class(x), "` yet.")
 }
 
 #' @rdname view_on_joint_distribution
@@ -851,14 +853,14 @@ construct_view_on_joint_distribution <- function(x, simul, p) {
   }
 
   # order 3
-  for (k in 1:N) {
-    for (l in k:N) {
-      for (i in l:k) {
-        Aeq <- rbind(Aeq, t(x[ , k] * x[ , l] * x[ , i]))
-        beq <- rbind(beq, t(simul[ , k] * simul[ , l] * simul[ , i]) %*% p)
-      }
-    }
-  }
+  # for (k in 1:N) {
+  #   for (l in k:N) {
+  #     for (i in l:k) {
+  #       Aeq <- rbind(Aeq, t(x[ , k] * x[ , l] * x[ , i]))
+  #       beq <- rbind(beq, t(simul[ , k] * simul[ , l] * simul[ , i]) %*% p)
+  #     }
+  #   }
+  # }
 
   vctrs::new_list_of(
     x      = list(Aeq = Aeq, beq = beq),

--- a/man/entropy_pooling.Rd
+++ b/man/entropy_pooling.Rd
@@ -40,7 +40,7 @@ the market).
 }
 \details{
 When imposing views constraints there is no need to specify the non-negativity
-constraint, which is done automatically by \code{entropy_pooling}.
+constraint for probabilities, which is done automatically by \code{entropy_pooling}.
 
 For the arguments accepted in \code{...}, please see the documentation of
 \code{\link[stats]{nlminb}}, \code{\link[NlcOptim]{solnl}} and \code{\link[nloptr]{nloptr}}.


### PR DESCRIPTION
These adjustments speed up the `entropy_pooling` function by 30% to 60%, depending on the optimizer. 

Error messages are now delivered by `rlang::abort`.